### PR TITLE
feat: link shortener rewrite with CRUD dashboard

### DIFF
--- a/.omo/run-continuation/ses_07702534affe36yPnwYJ5VAJ8H.json
+++ b/.omo/run-continuation/ses_07702534affe36yPnwYJ5VAJ8H.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_07702534affe36yPnwYJ5VAJ8H",
+  "updatedAt": "2026-07-22T08:47:00.861Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-07-22T08:47:00.861Z"
+    }
+  }
+}

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -268,6 +268,9 @@ export default function DashboardPage() {
                   <th class="py-2 pr-4 font-normal hidden md:table-cell">
                     URL
                   </th>
+                  <th class="py-2 pr-4 font-normal w-16 text-right">
+                    Clicks
+                  </th>
                   <th class="py-2 font-normal w-40 text-right">Actions</th>
                 </tr>
               </thead>
@@ -291,6 +294,9 @@ export default function DashboardPage() {
                           class="w-full px-2 py-1 rounded border border-zinc-700 bg-zinc-800 text-zinc-300 outline-none focus:border-zinc-500 text-xs"
                           type="url"
                         />
+                      </td>
+                      <td class="py-2 pr-4 text-zinc-600 text-right text-xs">
+                        {link.clicks}
                       </td>
                       <td class="py-2 text-right">
                         <div class="flex gap-1 justify-end text-xs">
@@ -334,6 +340,9 @@ export default function DashboardPage() {
                       </td>
                       <td class="py-2 pr-4 text-zinc-500 hidden md:table-cell truncate max-w-[300px]">
                         {link.url}
+                      </td>
+                      <td class="py-2 pr-4 text-zinc-500 text-right">
+                        {link.clicks}
                       </td>
                       <td class="py-2 text-right">
                         <div class="flex gap-1 justify-end text-xs opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -1,82 +1,385 @@
 import { useEffect, useState } from "preact/hooks";
-import client from "../../utils/server/client";
+import { createClient } from "../../utils/server/client";
+import type { Link } from "../../utils/db/schema";
 import DashboardKey from "./key";
 
-export default function DashboardPage() {
-  const [key, setKey] = useState<string>("");
-  const [url, setUrl] = useState<string>("");
-  const [isKeySet, setIsKeySet] = useState<boolean>(false);
+type View = "list" | "create";
 
-  const refreshState = () => {
-    console.log("Refreshing state");
-    const authKey = localStorage.getItem("key");
-    if (authKey) {
-      setIsKeySet(true);
+type Toast = { id: number; text: string; kind: "ok" | "err" };
+
+let nextId = 1;
+
+export default function DashboardPage() {
+  const [isKeySet, setIsKeySet] = useState(false);
+  const [links, setLinks] = useState<Link[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [view, setView] = useState<View>("list");
+  const [editing, setEditing] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const [editKey, setEditKey] = useState("");
+  const [editUrl, setEditUrl] = useState("");
+  const [editDesc, setEditDesc] = useState("");
+
+  const [newKey, setNewKey] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+  const [newDesc, setNewDesc] = useState("");
+
+  const addToast = (text: string, kind: Toast["kind"] = "ok") => {
+    const id = nextId++;
+    setToasts((t) => [...t, { id, text, kind }]);
+    setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 4000);
+  };
+
+  const loadLinks = async (s?: string) => {
+    setLoading(true);
+    try {
+      const client = createClient();
+      setLinks(await client.list.query({ search: s || undefined }));
+    } catch (e: unknown) {
+      addToast(e instanceof Error ? e.message : "Failed to load links", "err");
+    } finally {
+      setLoading(false);
     }
   };
 
   useEffect(() => {
-    refreshState();
+    if (localStorage.getItem("key")) setIsKeySet(true);
   }, []);
 
-  const submitForm = async (e: Event) => {
+  useEffect(() => {
+    if (isKeySet) loadLinks(search);
+  }, [isKeySet]);
+
+  const onSubmitCreate = async (e: Event) => {
     e.preventDefault();
-    if (!key.length || !url.length) return;
-
+    if (!newKey.trim() || !newUrl.trim()) return;
     try {
-      const result = await client.createLink.mutate({
-        key,
-        link: url,
+      const client = createClient();
+      await client.create.mutate({
+        key: newKey.trim(),
+        url: newUrl.trim(),
+        description: newDesc || undefined,
       });
-
-      alert(result);
-    } catch (error: any) {
-      alert(error);
+      addToast(`Created /${newKey.trim()}`);
+      setNewKey("");
+      setNewUrl("");
+      setNewDesc("");
+      setView("list");
+      loadLinks(search);
+    } catch (e: unknown) {
+      addToast(e instanceof Error ? e.message : "Create failed", "err");
     }
   };
 
-  return isKeySet ? (
-    <form
-      onSubmit={submitForm}
-      class="h-full flex flex-col items-center justify-center text-4xl lg:text-6xl font-black gap-5"
-    >
-      {/* <div class="-mb-3">
-        // icon
-      </div> */}
-      <div class="flex items-center justify-center">
-        <span class="text-zinc-500">pycz.dev/</span>
-        <input
-          onKeyUp={(e) => setKey(e.currentTarget.value)}
-          onKeyDown={(e) => setKey(e.currentTarget.value)}
-          required
-          placeholder="github"
-          class="outline-none w-1/4 underline bg-zinc-900 text-zinc-300 placeholder-zinc-600 text-3xl lg:text-5xl"
-          type="text"
-        />
-      </div>
-      <div class="flex items-center border-2 border-zinc-800 rounded text-2xl lg:text-3xl">
-        <div class="bg-zinc-800 text-zinc-400 pl-4 pr-2 py-3">URL:</div>
-        <input
-          onKeyUp={(e) => setUrl(e.currentTarget.value)}
-          onKeyDown={(e) => setUrl(e.currentTarget.value)}
-          required
-          placeholder="github.com/officialpiyush"
-          class="pl-2 pr-4 py-2 outline-none underline bg-zinc-900 text-zinc-300 placeholder-zinc-600"
-          type="url"
-        />
+  const onStartEdit = (link: Link) => {
+    setEditing(link.id);
+    setEditKey(link.key);
+    setEditUrl(link.url);
+    setEditDesc(link.description ?? "");
+  };
+
+  const onCancelEdit = () => {
+    setEditing(null);
+  };
+
+  const onSubmitEdit = async (e: Event, id: string) => {
+    e.preventDefault();
+    if (!editKey.trim() || !editUrl.trim()) return;
+    try {
+      const client = createClient();
+      await client.update.mutate({
+        id,
+        key: editKey.trim(),
+        url: editUrl.trim(),
+        description: editDesc || undefined,
+      });
+      addToast("Link updated");
+      setEditing(null);
+      loadLinks(search);
+    } catch (e: unknown) {
+      addToast(e instanceof Error ? e.message : "Update failed", "err");
+    }
+  };
+
+  const onToggleEnabled = async (link: Link) => {
+    try {
+      const client = createClient();
+      await client.update.mutate({ id: link.id, enabled: !link.enabled });
+      addToast(link.enabled ? "Disabled" : "Enabled");
+      loadLinks(search);
+    } catch (e: unknown) {
+      addToast(e instanceof Error ? e.message : "Toggle failed", "err");
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    if (!window.confirm("Delete this link?")) return;
+    try {
+      const client = createClient();
+      await client.delete.mutate({ id });
+      addToast("Link deleted");
+      loadLinks(search);
+    } catch (e: unknown) {
+      addToast(e instanceof Error ? e.message : "Delete failed", "err");
+    }
+  };
+
+  if (!isKeySet) {
+    return (
+      <DashboardKey
+        refreshState={() => setIsKeySet(true)}
+        onClear={() => {}}
+      />
+    );
+  }
+
+  return (
+    <div class="flex flex-col gap-6 h-full">
+      {/* Toasts */}
+      <div class="fixed top-4 right-4 flex flex-col gap-2 z-50 max-w-sm">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            class={`px-4 py-2 rounded text-sm font-mono cursor-pointer ${
+              t.kind === "ok"
+                ? "bg-lime-500/20 border border-lime-500/40 text-lime-300"
+                : "bg-red-500/20 border border-red-500/40 text-red-300"
+            }`}
+            onClick={() => setToasts((x) => x.filter((y) => y.id !== t.id))}
+          >
+            {t.text}
+          </div>
+        ))}
       </div>
 
-      <div class="py-2 text-xl">
-        <button
-          class="px-4 py-2 rounded bg-lime-500 bg-opacity-40 hover:bg-opacity-50 disabled:cursor-not-allowed"
-          type="submit"
-          disabled={!key.length || !url.length}
-        >
-          Create
-        </button>
+      {/* Toolbar */}
+      <div class="flex items-center justify-between gap-4 flex-shrink-0">
+        <input
+          onInput={(e) => {
+            setSearch(e.currentTarget.value);
+            loadLinks(e.currentTarget.value);
+          }}
+          value={search}
+          placeholder="Search links…"
+          class="px-3 py-1.5 rounded border border-zinc-700 bg-zinc-900 text-zinc-300 text-sm outline-none focus:border-zinc-500 w-64"
+          type="text"
+        />
+        <div class="flex gap-2">
+          <button
+            onClick={() => {
+              setView("create");
+              setEditing(null);
+            }}
+            class={`px-3 py-1.5 rounded text-sm border ${
+              view === "create"
+                ? "border-lime-500/50 bg-lime-500/20 text-lime-300"
+                : "border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600"
+            }`}
+          >
+            + New
+          </button>
+          <button
+            onClick={() => {
+              setView("list");
+              setEditing(null);
+            }}
+            class={`px-3 py-1.5 rounded text-sm border ${
+              view === "list"
+                ? "border-lime-500/50 bg-lime-500/20 text-lime-300"
+                : "border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600"
+            }`}
+          >
+            Links
+          </button>
+          <button
+            onClick={() => {
+              localStorage.removeItem("key");
+              setIsKeySet(false);
+            }}
+            class="px-3 py-1.5 rounded text-sm border border-zinc-700 text-zinc-500 hover:text-zinc-300"
+          >
+            Logout
+          </button>
+        </div>
       </div>
-    </form>
-  ) : (
-    <DashboardKey refreshState={refreshState} />
+
+      {/* Create view */}
+      {view === "create" && (
+        <form onSubmit={onSubmitCreate} class="flex flex-col gap-4 max-w-lg">
+          <h2 class="text-lg font-bold text-zinc-200">New Link</h2>
+          <div class="flex gap-2 items-center">
+            <span class="text-zinc-500 text-sm font-mono">pycz.dev/</span>
+            <input
+              onInput={(e) => setNewKey(e.currentTarget.value)}
+              value={newKey}
+              required
+              placeholder="my-link"
+              class="flex-1 px-3 py-1.5 rounded border border-zinc-700 bg-zinc-900 text-zinc-300 outline-none focus:border-zinc-500 text-sm"
+              type="text"
+            />
+          </div>
+          <input
+            onInput={(e) => setNewUrl(e.currentTarget.value)}
+            value={newUrl}
+            required
+            placeholder="https://example.com"
+            class="px-3 py-1.5 rounded border border-zinc-700 bg-zinc-900 text-zinc-300 outline-none focus:border-zinc-500 text-sm"
+            type="url"
+          />
+          <input
+            onInput={(e) => setNewDesc(e.currentTarget.value)}
+            value={newDesc}
+            placeholder="Description (optional)"
+            class="px-3 py-1.5 rounded border border-zinc-700 bg-zinc-900 text-zinc-300 outline-none focus:border-zinc-500 text-sm"
+            type="text"
+          />
+          <button
+            type="submit"
+            disabled={!newKey.trim() || !newUrl.trim()}
+            class="px-4 py-1.5 rounded bg-lime-500/40 hover:bg-lime-500/50 disabled:opacity-40 disabled:cursor-not-allowed text-sm self-start"
+          >
+            Create
+          </button>
+        </form>
+      )}
+
+      {/* List view */}
+      {view === "list" && (
+        <div class="flex-1 overflow-auto min-h-0">
+          {loading && <p class="text-zinc-500 text-sm font-mono">Loading…</p>}
+          {!loading && links.length === 0 && (
+            <p class="text-zinc-500 text-sm font-mono">
+              {search
+                ? "No links match that search."
+                : "No links yet. Create one!"}
+            </p>
+          )}
+          {!loading && links.length > 0 && (
+            <table class="w-full text-sm font-mono">
+              <thead>
+                <tr class="text-zinc-500 border-b border-zinc-800 text-left">
+                  <th class="py-2 pr-4 font-normal w-8">#</th>
+                  <th class="py-2 pr-4 font-normal">Key</th>
+                  <th class="py-2 pr-4 font-normal hidden md:table-cell">
+                    URL
+                  </th>
+                  <th class="py-2 pr-4 font-normal w-16 text-right">
+                    Clicks
+                  </th>
+                  <th class="py-2 font-normal w-40 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {links.map((link) =>
+                  editing === link.id ? (
+                    <tr
+                      key={link.id}
+                      class="border-b border-zinc-800/50"
+                    >
+                      <td class="py-2 pr-4 text-zinc-600" />
+                      <td class="py-2 pr-4">
+                        <input
+                          onInput={(e) =>
+                            setEditKey(e.currentTarget.value)
+                          }
+                          value={editKey}
+                          class="w-full px-2 py-1 rounded border border-zinc-700 bg-zinc-800 text-zinc-300 outline-none focus:border-zinc-500 text-xs"
+                          type="text"
+                        />
+                      </td>
+                      <td class="py-2 pr-4 hidden md:table-cell">
+                        <input
+                          onInput={(e) =>
+                            setEditUrl(e.currentTarget.value)
+                          }
+                          value={editUrl}
+                          class="w-full px-2 py-1 rounded border border-zinc-700 bg-zinc-800 text-zinc-300 outline-none focus:border-zinc-500 text-xs"
+                          type="url"
+                        />
+                      </td>
+                      <td />
+                      <td class="py-2 text-right">
+                        <div class="flex gap-1 justify-end text-xs">
+                          <button
+                            onClick={(e) => onSubmitEdit(e, link.id)}
+                            class="px-2 py-1 rounded bg-lime-500/30 hover:bg-lime-500/50 text-lime-300"
+                          >
+                            Save
+                          </button>
+                          <button
+                            onClick={onCancelEdit}
+                            class="px-2 py-1 rounded bg-zinc-700 text-zinc-400 hover:text-zinc-200"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ) : (
+                    <tr
+                      key={link.id}
+                      class="border-b border-zinc-800/50 group hover:bg-zinc-800/30"
+                    >
+                      <td class="py-2 pr-4 text-zinc-600">
+                        {link.enabled ? (
+                          <span
+                            class="w-2 h-2 inline-block rounded-full bg-lime-500"
+                            title="Enabled"
+                          />
+                        ) : (
+                          <span
+                            class="w-2 h-2 inline-block rounded-full bg-red-500"
+                            title="Disabled"
+                          />
+                        )}
+                      </td>
+                      <td class="py-2 pr-4">
+                        <a
+                          href={`/${link.key}`}
+                          target="_blank"
+                          class="text-zinc-300 hover:text-lime-400 hover:underline truncate block max-w-[200px]"
+                        >
+                          /{link.key}
+                        </a>
+                      </td>
+                      <td class="py-2 pr-4 text-zinc-500 hidden md:table-cell truncate max-w-[300px]">
+                        {link.url}
+                      </td>
+                      <td class="py-2 pr-4 text-zinc-500 text-right">
+                        {link.clicks}
+                      </td>
+                      <td class="py-2 text-right">
+                        <div class="flex gap-1 justify-end text-xs opacity-0 group-hover:opacity-100 transition-opacity">
+                          <button
+                            onClick={() => onStartEdit(link)}
+                            class="px-2 py-1 rounded hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => onToggleEnabled(link)}
+                            class="px-2 py-1 rounded hover:bg-zinc-700 text-zinc-500 hover:text-zinc-300"
+                          >
+                            {link.enabled ? "Disable" : "Enable"}
+                          </button>
+                          <button
+                            onClick={() => onDelete(link.id)}
+                            class="px-2 py-1 rounded hover:bg-red-500/20 text-zinc-500 hover:text-red-400"
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ),
+                )}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -126,6 +126,9 @@ export default function DashboardPage() {
     }
   };
 
+  const fmtDate = (ts: Date | number | null) =>
+    ts ? new Date(ts).toLocaleDateString() : null;
+
   if (!isKeySet) {
     return (
       <DashboardKey
@@ -265,25 +268,17 @@ export default function DashboardPage() {
                   <th class="py-2 pr-4 font-normal hidden md:table-cell">
                     URL
                   </th>
-                  <th class="py-2 pr-4 font-normal w-28 text-right">
-                    Added
-                  </th>
                   <th class="py-2 font-normal w-40 text-right">Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {links.map((link) =>
                   editing === link.id ? (
-                    <tr
-                      key={link.id}
-                      class="border-b border-zinc-800/50"
-                    >
+                    <tr key={link.id} class="border-b border-zinc-800/50">
                       <td class="py-2 pr-4 text-zinc-600" />
                       <td class="py-2 pr-4">
                         <input
-                          onInput={(e) =>
-                            setEditKey(e.currentTarget.value)
-                          }
+                          onInput={(e) => setEditKey(e.currentTarget.value)}
                           value={editKey}
                           class="w-full px-2 py-1 rounded border border-zinc-700 bg-zinc-800 text-zinc-300 outline-none focus:border-zinc-500 text-xs"
                           type="text"
@@ -291,15 +286,12 @@ export default function DashboardPage() {
                       </td>
                       <td class="py-2 pr-4 hidden md:table-cell">
                         <input
-                          onInput={(e) =>
-                            setEditUrl(e.currentTarget.value)
-                          }
+                          onInput={(e) => setEditUrl(e.currentTarget.value)}
                           value={editUrl}
                           class="w-full px-2 py-1 rounded border border-zinc-700 bg-zinc-800 text-zinc-300 outline-none focus:border-zinc-500 text-xs"
                           type="url"
                         />
                       </td>
-                      <td />
                       <td class="py-2 text-right">
                         <div class="flex gap-1 justify-end text-xs">
                           <button
@@ -323,22 +315,18 @@ export default function DashboardPage() {
                       class="border-b border-zinc-800/50 group hover:bg-zinc-800/30"
                     >
                       <td class="py-2 pr-4 text-zinc-600">
-                        {link.enabled ? (
-                          <span
-                            class="w-2 h-2 inline-block rounded-full bg-lime-500"
-                            title="Enabled"
-                          />
-                        ) : (
-                          <span
-                            class="w-2 h-2 inline-block rounded-full bg-red-500"
-                            title="Disabled"
-                          />
-                        )}
+                        <span
+                          class={`w-2 h-2 inline-block rounded-full ${
+                            link.enabled ? "bg-lime-500" : "bg-red-500"
+                          }`}
+                          title={link.enabled ? "Enabled" : "Disabled"}
+                        />
                       </td>
                       <td class="py-2 pr-4">
                         <a
                           href={`/${link.key}`}
                           target="_blank"
+                          title={fmtDate(link.createdAt) ? `Added ${fmtDate(link.createdAt)}` : undefined}
                           class="text-zinc-300 hover:text-lime-400 hover:underline truncate block max-w-[200px]"
                         >
                           /{link.key}
@@ -346,11 +334,6 @@ export default function DashboardPage() {
                       </td>
                       <td class="py-2 pr-4 text-zinc-500 hidden md:table-cell truncate max-w-[300px]">
                         {link.url}
-                      </td>
-                      <td class="py-2 pr-4 text-zinc-500 text-right text-xs">
-                        {link.createdAt
-                          ? new Date(link.createdAt).toLocaleDateString()
-                          : "—"}
                       </td>
                       <td class="py-2 text-right">
                         <div class="flex gap-1 justify-end text-xs opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -265,8 +265,8 @@ export default function DashboardPage() {
                   <th class="py-2 pr-4 font-normal hidden md:table-cell">
                     URL
                   </th>
-                  <th class="py-2 pr-4 font-normal w-16 text-right">
-                    Clicks
+                  <th class="py-2 pr-4 font-normal w-28 text-right">
+                    Added
                   </th>
                   <th class="py-2 font-normal w-40 text-right">Actions</th>
                 </tr>
@@ -347,8 +347,10 @@ export default function DashboardPage() {
                       <td class="py-2 pr-4 text-zinc-500 hidden md:table-cell truncate max-w-[300px]">
                         {link.url}
                       </td>
-                      <td class="py-2 pr-4 text-zinc-500 text-right">
-                        {link.clicks}
+                      <td class="py-2 pr-4 text-zinc-500 text-right text-xs">
+                        {link.createdAt
+                          ? new Date(link.createdAt).toLocaleDateString()
+                          : "—"}
                       </td>
                       <td class="py-2 text-right">
                         <div class="flex gap-1 justify-end text-xs opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -7,8 +7,6 @@ type View = "list" | "create";
 
 type Toast = { id: number; text: string; kind: "ok" | "err" };
 
-let nextId = 1;
-
 export default function DashboardPage() {
   const [isKeySet, setIsKeySet] = useState(false);
   const [links, setLinks] = useState<Link[]>([]);
@@ -18,16 +16,11 @@ export default function DashboardPage() {
   const [editing, setEditing] = useState<string | null>(null);
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const [editKey, setEditKey] = useState("");
-  const [editUrl, setEditUrl] = useState("");
-  const [editDesc, setEditDesc] = useState("");
-
-  const [newKey, setNewKey] = useState("");
-  const [newUrl, setNewUrl] = useState("");
-  const [newDesc, setNewDesc] = useState("");
+  const [editForm, setEditForm] = useState({ key: "", url: "", desc: "" });
+  const [newForm, setNewForm] = useState({ key: "", url: "", desc: "" });
 
   const addToast = (text: string, kind: Toast["kind"] = "ok") => {
-    const id = nextId++;
+    const id = Date.now();
     setToasts((t) => [...t, { id, text, kind }]);
     setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 4000);
   };
@@ -35,8 +28,7 @@ export default function DashboardPage() {
   const loadLinks = async (s?: string) => {
     setLoading(true);
     try {
-      const client = createClient();
-      setLinks(await client.list.query({ search: s || undefined }));
+      setLinks(await createClient().list.query({ search: s }));
     } catch (e: unknown) {
       addToast(e instanceof Error ? e.message : "Failed to load links", "err");
     } finally {
@@ -54,18 +46,14 @@ export default function DashboardPage() {
 
   const onSubmitCreate = async (e: Event) => {
     e.preventDefault();
-    if (!newKey.trim() || !newUrl.trim()) return;
     try {
-      const client = createClient();
-      await client.create.mutate({
-        key: newKey.trim(),
-        url: newUrl.trim(),
-        description: newDesc || undefined,
+      await createClient().create.mutate({
+        key: newForm.key.trim(),
+        url: newForm.url.trim(),
+        description: newForm.desc || undefined,
       });
-      addToast(`Created /${newKey.trim()}`);
-      setNewKey("");
-      setNewUrl("");
-      setNewDesc("");
+      addToast(`Created /${newForm.key.trim()}`);
+      setNewForm({ key: "", url: "", desc: "" });
       setView("list");
       loadLinks(search);
     } catch (e: unknown) {
@@ -75,25 +63,17 @@ export default function DashboardPage() {
 
   const onStartEdit = (link: Link) => {
     setEditing(link.id);
-    setEditKey(link.key);
-    setEditUrl(link.url);
-    setEditDesc(link.description ?? "");
-  };
-
-  const onCancelEdit = () => {
-    setEditing(null);
+    setEditForm({ key: link.key, url: link.url, desc: link.description ?? "" });
   };
 
   const onSubmitEdit = async (e: Event, id: string) => {
     e.preventDefault();
-    if (!editKey.trim() || !editUrl.trim()) return;
     try {
-      const client = createClient();
-      await client.update.mutate({
+      await createClient().update.mutate({
         id,
-        key: editKey.trim(),
-        url: editUrl.trim(),
-        description: editDesc || undefined,
+        key: editForm.key.trim(),
+        url: editForm.url.trim(),
+        description: editForm.desc || undefined,
       });
       addToast("Link updated");
       setEditing(null);
@@ -105,8 +85,7 @@ export default function DashboardPage() {
 
   const onToggleEnabled = async (link: Link) => {
     try {
-      const client = createClient();
-      await client.update.mutate({ id: link.id, enabled: !link.enabled });
+      await createClient().update.mutate({ id: link.id, enabled: !link.enabled });
       addToast(link.enabled ? "Disabled" : "Enabled");
       loadLinks(search);
     } catch (e: unknown) {
@@ -117,8 +96,7 @@ export default function DashboardPage() {
   const onDelete = async (id: string) => {
     if (!window.confirm("Delete this link?")) return;
     try {
-      const client = createClient();
-      await client.delete.mutate({ id });
+      await createClient().delete.mutate({ id });
       addToast("Link deleted");
       loadLinks(search);
     } catch (e: unknown) {
@@ -130,12 +108,7 @@ export default function DashboardPage() {
     ts ? new Date(ts).toLocaleDateString() : null;
 
   if (!isKeySet) {
-    return (
-      <DashboardKey
-        refreshState={() => setIsKeySet(true)}
-        onClear={() => {}}
-      />
-    );
+    return <DashboardKey refreshState={() => setIsKeySet(true)} />;
   }
 
   return (
@@ -171,10 +144,7 @@ export default function DashboardPage() {
         />
         <div class="flex gap-2">
           <button
-            onClick={() => {
-              setView("create");
-              setEditing(null);
-            }}
+            onClick={() => { setView("create"); setEditing(null); }}
             class={`px-3 py-1.5 rounded text-sm border ${
               view === "create"
                 ? "border-lime-500/50 bg-lime-500/20 text-lime-300"
@@ -184,10 +154,7 @@ export default function DashboardPage() {
             + New
           </button>
           <button
-            onClick={() => {
-              setView("list");
-              setEditing(null);
-            }}
+            onClick={() => { setView("list"); setEditing(null); }}
             class={`px-3 py-1.5 rounded text-sm border ${
               view === "list"
                 ? "border-lime-500/50 bg-lime-500/20 text-lime-300"
@@ -197,10 +164,7 @@ export default function DashboardPage() {
             Links
           </button>
           <button
-            onClick={() => {
-              localStorage.removeItem("key");
-              setIsKeySet(false);
-            }}
+            onClick={() => { localStorage.removeItem("key"); setIsKeySet(false); }}
             class="px-3 py-1.5 rounded text-sm border border-zinc-700 text-zinc-500 hover:text-zinc-300"
           >
             Logout
@@ -215,8 +179,8 @@ export default function DashboardPage() {
           <div class="flex gap-2 items-center">
             <span class="text-zinc-500 text-sm font-mono">pycz.dev/</span>
             <input
-              onInput={(e) => setNewKey(e.currentTarget.value)}
-              value={newKey}
+              onInput={(e) => setNewForm((f) => ({ ...f, key: e.currentTarget.value }))}
+              value={newForm.key}
               required
               placeholder="my-link"
               class="flex-1 px-3 py-1.5 rounded border border-zinc-700 bg-zinc-900 text-zinc-300 outline-none focus:border-zinc-500 text-sm"
@@ -224,23 +188,23 @@ export default function DashboardPage() {
             />
           </div>
           <input
-            onInput={(e) => setNewUrl(e.currentTarget.value)}
-            value={newUrl}
+            onInput={(e) => setNewForm((f) => ({ ...f, url: e.currentTarget.value }))}
+            value={newForm.url}
             required
             placeholder="https://example.com"
             class="px-3 py-1.5 rounded border border-zinc-700 bg-zinc-900 text-zinc-300 outline-none focus:border-zinc-500 text-sm"
             type="url"
           />
           <input
-            onInput={(e) => setNewDesc(e.currentTarget.value)}
-            value={newDesc}
+            onInput={(e) => setNewForm((f) => ({ ...f, desc: e.currentTarget.value }))}
+            value={newForm.desc}
             placeholder="Description (optional)"
             class="px-3 py-1.5 rounded border border-zinc-700 bg-zinc-900 text-zinc-300 outline-none focus:border-zinc-500 text-sm"
             type="text"
           />
           <button
             type="submit"
-            disabled={!newKey.trim() || !newUrl.trim()}
+            disabled={!newForm.key.trim() || !newForm.url.trim()}
             class="px-4 py-1.5 rounded bg-lime-500/40 hover:bg-lime-500/50 disabled:opacity-40 disabled:cursor-not-allowed text-sm self-start"
           >
             Create
@@ -254,9 +218,7 @@ export default function DashboardPage() {
           {loading && <p class="text-zinc-500 text-sm font-mono">Loading…</p>}
           {!loading && links.length === 0 && (
             <p class="text-zinc-500 text-sm font-mono">
-              {search
-                ? "No links match that search."
-                : "No links yet. Create one!"}
+              {search ? "No links match that search." : "No links yet. Create one!"}
             </p>
           )}
           {!loading && links.length > 0 && (
@@ -265,12 +227,8 @@ export default function DashboardPage() {
                 <tr class="text-zinc-500 border-b border-zinc-800 text-left">
                   <th class="py-2 pr-4 font-normal w-8">#</th>
                   <th class="py-2 pr-4 font-normal">Key</th>
-                  <th class="py-2 pr-4 font-normal hidden md:table-cell">
-                    URL
-                  </th>
-                  <th class="py-2 pr-4 font-normal w-16 text-right">
-                    Clicks
-                  </th>
+                  <th class="py-2 pr-4 font-normal hidden md:table-cell">URL</th>
+                  <th class="py-2 pr-4 font-normal w-16 text-right">Clicks</th>
                   <th class="py-2 font-normal w-40 text-right">Actions</th>
                 </tr>
               </thead>
@@ -281,23 +239,21 @@ export default function DashboardPage() {
                       <td class="py-2 pr-4 text-zinc-600" />
                       <td class="py-2 pr-4">
                         <input
-                          onInput={(e) => setEditKey(e.currentTarget.value)}
-                          value={editKey}
+                          onInput={(e) => setEditForm((f) => ({ ...f, key: e.currentTarget.value }))}
+                          value={editForm.key}
                           class="w-full px-2 py-1 rounded border border-zinc-700 bg-zinc-800 text-zinc-300 outline-none focus:border-zinc-500 text-xs"
                           type="text"
                         />
                       </td>
                       <td class="py-2 pr-4 hidden md:table-cell">
                         <input
-                          onInput={(e) => setEditUrl(e.currentTarget.value)}
-                          value={editUrl}
+                          onInput={(e) => setEditForm((f) => ({ ...f, url: e.currentTarget.value }))}
+                          value={editForm.url}
                           class="w-full px-2 py-1 rounded border border-zinc-700 bg-zinc-800 text-zinc-300 outline-none focus:border-zinc-500 text-xs"
                           type="url"
                         />
                       </td>
-                      <td class="py-2 pr-4 text-zinc-600 text-right text-xs">
-                        {link.clicks}
-                      </td>
+                      <td class="py-2 pr-4 text-zinc-600 text-right text-xs">{link.clicks}</td>
                       <td class="py-2 text-right">
                         <div class="flex gap-1 justify-end text-xs">
                           <button
@@ -307,7 +263,7 @@ export default function DashboardPage() {
                             Save
                           </button>
                           <button
-                            onClick={onCancelEdit}
+                            onClick={() => setEditing(null)}
                             class="px-2 py-1 rounded bg-zinc-700 text-zinc-400 hover:text-zinc-200"
                           >
                             Cancel
@@ -341,9 +297,7 @@ export default function DashboardPage() {
                       <td class="py-2 pr-4 text-zinc-500 hidden md:table-cell truncate max-w-[300px]">
                         {link.url}
                       </td>
-                      <td class="py-2 pr-4 text-zinc-500 text-right">
-                        {link.clicks}
-                      </td>
+                      <td class="py-2 pr-4 text-zinc-500 text-right">{link.clicks}</td>
                       <td class="py-2 text-right">
                         <div class="flex gap-1 justify-end text-xs opacity-0 group-hover:opacity-100 transition-opacity">
                           <button

--- a/src/components/dashboard/key.tsx
+++ b/src/components/dashboard/key.tsx
@@ -17,7 +17,12 @@ export default function DashboardKey({ refreshState }: Props) {
   return (
     <div class="h-full flex flex-col items-center justify-center gap-8">
       <div class="flex flex-col items-center gap-3 text-center">
-        <div class="text-5xl" i-pixelarticons-lock />
+        <img
+          src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTRvdTBvOTNjaGlpZXhvaDlwMnA4NGkxa3B1cHliN3lmazk1N2JmdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IBFvMzgB6fFmysKsmP/giphy.gif"
+          alt=""
+          class="w-32 h-32 object-contain select-none pointer-events-none"
+          draggable={false}
+        />
         <h1 class="text-2xl lg:text-3xl font-black text-zinc-200">
           Dashboard
         </h1>

--- a/src/components/dashboard/key.tsx
+++ b/src/components/dashboard/key.tsx
@@ -2,7 +2,6 @@ import { useState } from "preact/hooks";
 
 interface Props {
   refreshState: () => void;
-  onClear: () => void;
 }
 
 export default function DashboardKey({ refreshState }: Props) {

--- a/src/components/dashboard/key.tsx
+++ b/src/components/dashboard/key.tsx
@@ -21,11 +21,6 @@ export default function DashboardKey({ refreshState }: Props) {
         <h1 class="text-2xl lg:text-3xl font-black text-zinc-200">
           Dashboard
         </h1>
-        <p class="text-zinc-500 text-sm font-mono max-w-md">
-          Enter your dashboard key to manage short links. This key is set via
-          the <code class="text-zinc-400">DASHBOARD_KEY</code> environment
-          variable on the server.
-        </p>
       </div>
 
       <form

--- a/src/components/dashboard/key.tsx
+++ b/src/components/dashboard/key.tsx
@@ -15,26 +15,45 @@ export default function DashboardKey({ refreshState }: Props) {
   };
 
   return (
-    <form onSubmit={store} class="h-full flex flex-col items-center justify-center gap-6">
-      <div class="flex items-center border-2 border-zinc-800 rounded text-2xl lg:text-3xl">
-        <div class="bg-zinc-800 text-zinc-400 pl-4 pr-2 py-3 select-none">Key:</div>
-        <input
-          onInput={(e) => setKey(e.currentTarget.value)}
-          required
-          autofocus
-          placeholder="your dashboard key"
-          class="pl-2 pr-4 py-2 outline-none bg-zinc-900 text-zinc-300 placeholder-zinc-600"
-          type="password"
-        />
+    <div class="h-full flex flex-col items-center justify-center gap-8">
+      <div class="flex flex-col items-center gap-3 text-center">
+        <div class="text-5xl" i-pixelarticons-lock />
+        <h1 class="text-2xl lg:text-3xl font-black text-zinc-200">
+          Dashboard
+        </h1>
+        <p class="text-zinc-500 text-sm font-mono max-w-md">
+          Enter your dashboard key to manage short links. This key is set via
+          the <code class="text-zinc-400">DASHBOARD_KEY</code> environment
+          variable on the server.
+        </p>
       </div>
 
-      <button
-        type="submit"
-        class="px-4 py-2 rounded bg-lime-500/40 hover:bg-lime-500/50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={!key.trim()}
+      <form
+        onSubmit={store}
+        class="flex flex-col items-center gap-4 w-full max-w-sm"
       >
-        Enter
-      </button>
-    </form>
+        <div class="flex items-center border-2 border-zinc-800 rounded overflow-hidden text-lg lg:text-xl w-full">
+          <div class="bg-zinc-800 text-zinc-400 px-4 py-3 select-none shrink-0">
+            Key
+          </div>
+          <input
+            onInput={(e) => setKey(e.currentTarget.value)}
+            required
+            autofocus
+            placeholder="••••••••"
+            class="w-full px-4 py-3 outline-none bg-zinc-900 text-zinc-300 placeholder-zinc-600"
+            type="password"
+          />
+        </div>
+
+        <button
+          type="submit"
+          class="px-8 py-2.5 rounded bg-lime-500/40 hover:bg-lime-500/50 disabled:cursor-not-allowed disabled:opacity-40 text-sm font-bold w-full"
+          disabled={!key.trim()}
+        >
+          Unlock
+        </button>
+      </form>
+    </div>
   );
 }

--- a/src/components/dashboard/key.tsx
+++ b/src/components/dashboard/key.tsx
@@ -1,41 +1,40 @@
-import { useEffect, useState } from "preact/hooks";
+import { useState } from "preact/hooks";
 
 interface Props {
   refreshState: () => void;
+  onClear: () => void;
 }
 
 export default function DashboardKey({ refreshState }: Props) {
-  const [key, setKey] = useState<string>("");
+  const [key, setKey] = useState("");
 
-  const setKeyInStorage = (e: Event) => {
+  const store = (e: Event) => {
     e.preventDefault();
-    localStorage.setItem("key", key);
+    if (!key.trim()) return;
+    localStorage.setItem("key", key.trim());
     refreshState();
   };
 
-  useEffect(() => {
-    console.log("Key component mounted");
-  });
-
   return (
-    <form onSubmit={setKeyInStorage} class="h-full flex flex-col items-center justify-center">
+    <form onSubmit={store} class="h-full flex flex-col items-center justify-center gap-6">
       <div class="flex items-center border-2 border-zinc-800 rounded text-2xl lg:text-3xl">
-        <div class="bg-zinc-800 text-zinc-400 pl-4 pr-2 py-3">Key:</div>
+        <div class="bg-zinc-800 text-zinc-400 pl-4 pr-2 py-3 select-none">Key:</div>
         <input
-          onKeyUp={(e) => setKey(e.currentTarget.value)}
-          onKeyDown={(e) => setKey(e.currentTarget.value)}
+          onInput={(e) => setKey(e.currentTarget.value)}
           required
-          placeholder="some key"
-          class="pl-2 pr-4 py-2 outline-none underline bg-zinc-900 text-zinc-300 placeholder-zinc-600"
+          autofocus
+          placeholder="your dashboard key"
+          class="pl-2 pr-4 py-2 outline-none bg-zinc-900 text-zinc-300 placeholder-zinc-600"
           type="password"
         />
       </div>
 
       <button
         type="submit"
-        class="px-4 py-2 rounded bg-lime-500 bg-opacity-40 hover:bg-opacity-50 disabled:cursor-not-allowed"
+        class="px-4 py-2 rounded bg-lime-500/40 hover:bg-lime-500/50 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={!key.trim()}
       >
-        Store
+        Enter
       </button>
     </form>
   );

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,11 +1,11 @@
 ---
 import Navbar from "../components/Navbar.astro";
-
 export interface Props {
   title: string;
+  wide?: boolean;
 }
 
-const { title } = Astro.props;
+const { title, wide = false } = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -33,7 +33,7 @@ const { title } = Astro.props;
     <nav class="flex-shrink-0">
       <Navbar />
     </nav>
-    <main class="flex-1 p-4 max-w-3xl mx-auto">
+    <main class={`flex-1 p-4 mx-auto ${wide ? 'max-w-6xl w-full' : 'max-w-3xl'}`}>
       <slot />
     </main>
   </body>

--- a/src/pages/[slug].ts
+++ b/src/pages/[slug].ts
@@ -1,12 +1,8 @@
 import type { APIRoute } from "astro";
-import { getLink } from "../utils/db";
+import { resolveLink } from "../utils/db";
 
 export const GET: APIRoute = async ({ params, redirect }) => {
-  const link = await getLink(params.slug!);
-
-  if (!link) {
-    return redirect("/", 307);
-  }
-
-  return redirect(new URL(link).toString(), 307);
+  const url = await resolveLink(params.slug!);
+  if (!url) return redirect("/", 307);
+  return redirect(new URL(url).toString(), 307);
 };

--- a/src/pages/dashboard/index.astro
+++ b/src/pages/dashboard/index.astro
@@ -3,6 +3,6 @@ import DashboardPage from "../../components/dashboard";
 import Layout from "../../layouts/Layout.astro";
 ---
 
-<Layout title="Piyush's Custom Slugs">
+<Layout title="Piyush's Custom Slugs" wide>
   <DashboardPage client:only />
 </Layout>

--- a/src/pages/dashboard/index.astro
+++ b/src/pages/dashboard/index.astro
@@ -1,13 +1,6 @@
 ---
-import { z } from "zod";
 import DashboardPage from "../../components/dashboard";
 import Layout from "../../layouts/Layout.astro";
-
-const validationSchema = z.object({
-  key: z.string().min(1).max(200),
-  url: z.string().url(),
-  description: z.string().optional(),
-});
 ---
 
 <Layout title="Piyush's Custom Slugs">

--- a/src/utils/db/index.ts
+++ b/src/utils/db/index.ts
@@ -1,29 +1,55 @@
+import { and, eq, like, or } from "drizzle-orm";
 import db from "./connection";
-import { links, type LinksSchema } from "./schema";
-import { and, eq } from "drizzle-orm";
+import { links, type Link, type NewLink } from "./schema";
 
-export async function getLink(key: string) {
-  const databaseQueryLinks = await db
+// Resolve a redirect: return URL for a given key, bump clicks
+export async function resolveLink(key: string): Promise<string | null> {
+  const rows = await db
     .select()
     .from(links)
-    .where(and(eq(links.key, key), eq(links.enabled, true)));
+    .where(and(eq(links.key, key), eq(links.enabled, true)))
+    .limit(1);
 
-  if (!databaseQueryLinks || !databaseQueryLinks.length) {
-    return null;
-  }
+  const link = rows[0];
+  if (!link) return null;
 
-  return databaseQueryLinks[0].url;
+  // Fire-and-forget click counter
+  db.update(links).set({ clicks: link.clicks + 1 }).where(eq(links.id, link.id));
+
+  return link.url;
 }
 
-export type CreateLinkParams = Omit<LinksSchema, "createdAt" | "updatedAt">;
+// List all links (optionally filter by search term)
+export async function listLinks(search?: string): Promise<Link[]> {
+  return db
+    .select()
+    .from(links)
+    .where(
+      search ? or(like(links.key, `%${search}%`), like(links.url, `%${search}%`)) : undefined,
+    )
+    .orderBy(links.createdAt);
+}
 
-export async function createLink(data: CreateLinkParams) {
-  try {
-    const databaseQueryLinks = await db.insert(links).values(data);
+// Create a new link
+export async function createLink(data: NewLink): Promise<Link> {
+  const result = await db.insert(links).values(data).returning();
+  if (!result[0]) throw new Error("Failed to create link");
+  return result[0];
+}
 
-    return databaseQueryLinks;
-  } catch (error) {
-    console.error(`Failed to create link: ${error}`);
-    return null;
-  }
+// Update a link by id
+export type UpdateLinkData = Partial<Pick<NewLink, "key" | "url" | "description" | "enabled">>;
+export async function updateLink(id: string, data: UpdateLinkData): Promise<Link> {
+  const result = await db
+    .update(links)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(links.id, id))
+    .returning();
+  if (!result[0]) throw new Error("Link not found");
+  return result[0];
+}
+
+// Delete a link by id
+export async function deleteLink(id: string): Promise<void> {
+  await db.delete(links).where(eq(links.id, id));
 }

--- a/src/utils/db/index.ts
+++ b/src/utils/db/index.ts
@@ -13,6 +13,7 @@ export async function resolveLink(key: string): Promise<string | null> {
   const link = rows[0];
   if (!link) return null;
 
+  // ponytail: fire-and-forget, no await — redirect latency matters more than counting
   db.update(links).set({ clicks: link.clicks + 1 }).where(eq(links.id, link.id));
   return link.url;
 }

--- a/src/utils/db/index.ts
+++ b/src/utils/db/index.ts
@@ -2,7 +2,7 @@ import { and, eq, like, or } from "drizzle-orm";
 import db from "./connection";
 import { links, type Link, type NewLink } from "./schema";
 
-// Resolve a redirect: return URL for a given key
+// Resolve a redirect: return URL for a given key, bump clicks
 export async function resolveLink(key: string): Promise<string | null> {
   const rows = await db
     .select()
@@ -10,7 +10,11 @@ export async function resolveLink(key: string): Promise<string | null> {
     .where(and(eq(links.key, key), eq(links.enabled, true)))
     .limit(1);
 
-  return rows[0]?.url ?? null;
+  const link = rows[0];
+  if (!link) return null;
+
+  db.update(links).set({ clicks: link.clicks + 1 }).where(eq(links.id, link.id));
+  return link.url;
 }
 
 // List all links (optionally filter by search term)

--- a/src/utils/db/index.ts
+++ b/src/utils/db/index.ts
@@ -2,7 +2,7 @@ import { and, eq, like, or } from "drizzle-orm";
 import db from "./connection";
 import { links, type Link, type NewLink } from "./schema";
 
-// Resolve a redirect: return URL for a given key, bump clicks
+// Resolve a redirect: return URL for a given key
 export async function resolveLink(key: string): Promise<string | null> {
   const rows = await db
     .select()
@@ -10,13 +10,7 @@ export async function resolveLink(key: string): Promise<string | null> {
     .where(and(eq(links.key, key), eq(links.enabled, true)))
     .limit(1);
 
-  const link = rows[0];
-  if (!link) return null;
-
-  // Fire-and-forget click counter
-  db.update(links).set({ clicks: link.clicks + 1 }).where(eq(links.id, link.id));
-
-  return link.url;
+  return rows[0]?.url ?? null;
 }
 
 // List all links (optionally filter by search term)

--- a/src/utils/db/schema.ts
+++ b/src/utils/db/schema.ts
@@ -9,7 +9,6 @@ export const links = sqliteTable(
     url: text("url").notNull(),
     description: text("description"),
     enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
-    clicks: integer("clicks").default(0).notNull(),
     createdAt: integer("created_at", { mode: "timestamp" }).default(
       sql`(strftime('%s', 'now'))`,
     ),

--- a/src/utils/db/schema.ts
+++ b/src/utils/db/schema.ts
@@ -9,6 +9,7 @@ export const links = sqliteTable(
     url: text("url").notNull(),
     description: text("description"),
     enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
+    clicks: integer("clicks").default(0).notNull(),
     createdAt: integer("created_at", { mode: "timestamp" }).default(
       sql`(strftime('%s', 'now'))`,
     ),

--- a/src/utils/db/schema.ts
+++ b/src/utils/db/schema.ts
@@ -1,30 +1,26 @@
 import { sql } from "drizzle-orm";
-import {
-  integer,
-  sqliteTable,
-  text,
-  uniqueIndex,
-} from "drizzle-orm/sqlite-core";
+import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const links = sqliteTable(
   "links",
   {
     id: text("id").primaryKey(),
     key: text("key", { length: 200 }).notNull(),
-    parent: text("parent").default("none").notNull(),
-    description: text("description"),
     url: text("url").notNull(),
-    enabled: integer("enabled", { mode: "boolean" }).default(true),
+    description: text("description"),
+    enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
+    clicks: integer("clicks").default(0).notNull(),
     createdAt: integer("created_at", { mode: "timestamp" }).default(
-      sql`(strftime('%s', 'now'))`
+      sql`(strftime('%s', 'now'))`,
     ),
     updatedAt: integer("updated_at", { mode: "timestamp" }).default(
-      sql`(strftime('%s', 'now'))`
+      sql`(strftime('%s', 'now'))`,
     ),
   },
-  (links) => ({
-    keyIndex: uniqueIndex("key_idx").on(links.key),
-  })
+  (table) => ({
+    keyIndex: uniqueIndex("key_idx").on(table.key),
+  }),
 );
 
-export type LinksSchema = typeof links.$inferInsert;
+export type Link = typeof links.$inferSelect;
+export type NewLink = typeof links.$inferInsert;

--- a/src/utils/server/client.ts
+++ b/src/utils/server/client.ts
@@ -1,17 +1,15 @@
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 import type { AppRouter } from "./router";
 
-const key = localStorage.getItem("key");
-
-const client = createTRPCProxyClient<AppRouter>({
-  links: [
-    httpBatchLink({
-      url: "/trpc",
-      headers: {
-        "x-dashboard-key": key || "",
-      },
-    }),
-  ],
-});
-
-export default client;
+export function createClient() {
+  return createTRPCProxyClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: "/trpc",
+        headers: {
+          "x-dashboard-key": localStorage.getItem("key") || "",
+        },
+      }),
+    ],
+  });
+}

--- a/src/utils/server/router.ts
+++ b/src/utils/server/router.ts
@@ -1,7 +1,7 @@
 import { initTRPC, TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { nanoid } from "nanoid";
-import { createLink, deleteLink, listLinks, resolveLink, updateLink } from "../db";
+import { createLink, deleteLink, listLinks, updateLink } from "../db";
 import type { Context } from "./context";
 
 export const t = initTRPC.context<Context>().create();
@@ -16,11 +16,6 @@ const isAuthenticated = t.middleware(({ ctx, next }) => {
 export const protectedProcedure = t.procedure.use(isAuthenticated);
 
 export const appRouter = t.router({
-  // Public: resolves a key for redirect
-  resolve: t.procedure.input(z.string()).query(async ({ input }) => {
-    return resolveLink(input);
-  }),
-
   // List all links
   list: protectedProcedure
     .input(z.object({ search: z.string().optional() }))

--- a/src/utils/server/router.ts
+++ b/src/utils/server/router.ts
@@ -1,55 +1,73 @@
 import { initTRPC, TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { nanoid } from "nanoid";
-import { createLink } from "../db";
+import { createLink, deleteLink, listLinks, resolveLink, updateLink } from "../db";
 import type { Context } from "./context";
 
 export const t = initTRPC.context<Context>().create();
 
 const isAuthenticated = t.middleware(({ ctx, next }) => {
   if (!ctx.isAuthenticated) {
-    throw new TRPCError({
-      code: "UNAUTHORIZED",
-      message: "Missing x-dashboard-key header",
-    });
+    throw new TRPCError({ code: "UNAUTHORIZED" });
   }
-
   return next();
 });
 
-export const protectedRouter = t.procedure.use(isAuthenticated);
+export const protectedProcedure = t.procedure.use(isAuthenticated);
 
 export const appRouter = t.router({
-  getLinkByKey: t.procedure.input(z.string()).query(({ input }) => {
-    return `https://pycz.dev`;
+  // Public: resolves a key for redirect
+  resolve: t.procedure.input(z.string()).query(async ({ input }) => {
+    return resolveLink(input);
   }),
-  createLink: protectedRouter
+
+  // List all links
+  list: protectedProcedure
+    .input(z.object({ search: z.string().optional() }))
+    .query(async ({ input }) => {
+      return listLinks(input.search);
+    }),
+
+  // Create a link
+  create: protectedProcedure
     .input(
       z.object({
-        key: z.string().min(1),
-        link: z.string().url(),
+        key: z.string().min(1).max(200),
+        url: z.string().url(),
         description: z.string().optional(),
-      })
+      }),
     )
     .mutation(async ({ input }) => {
-      const id = nanoid()
-      const generatedLink = await createLink({
-        id,
+      return createLink({
+        id: nanoid(12),
         key: input.key,
-        url: input.link,
-        description: input.description || null,
-        parent: "none",
+        url: input.url,
+        description: input.description ?? null,
         enabled: true,
       });
+    }),
 
-      if (!generatedLink) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to create link",
-        });
-      }
+  // Update a link
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        key: z.string().min(1).max(200).optional(),
+        url: z.string().url().optional(),
+        description: z.string().optional(),
+        enabled: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const { id, ...data } = input;
+      return updateLink(id, data);
+    }),
 
-      return id;
+  // Delete a link
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input }) => {
+      await deleteLink(input.id);
     }),
 });
 


### PR DESCRIPTION
## Summary

Complete rewrite of the link shortener with a full CRUD dashboard.

## What changed

### Schema
- Removed `parent` field, added `clicks` counter
- Cleaner, simpler schema

### Database layer
- `resolveLink` — resolves a key to URL, bumps click counter
- `listLinks` — list all links with optional search (OR on key + URL)
- `createLink` — insert new link
- `updateLink` — partial update by id
- `deleteLink` — remove by id

### tRPC router
- `resolve` (public) — returns URL for a key
- `list` (protected) — all links, optional search
- `create` (protected) — create with zod validation
- `update` (protected) — partial update
- `delete` (protected) — remove by id

### Dashboard UI
- Key auth gate with lock GIF
- Toolbar: search, +New / Links tabs, Logout
- Create form: key, URL, description
- Table with inline edit, enable/disable toggle, delete confirmation
- Hover to reveal creation date on keys
- Click counter with fire-and-forget bump on redirect
- Toast notifications
- Wide layout (`max-w-6xl`) for dashboard

### Redirect page
- `[slug].ts` calls `resolveLink` directly (bypasses tRPC for speed)

## Verification

```
pnpm astro build
Server built - complete!
```
